### PR TITLE
Add an option to clear listItems, filteredList and reset input text

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -122,6 +122,9 @@
 
   // option to show clear selection button
   export let showClear = false;
+  
+  // option to clear the current list of items after selecting an item
+  export let clearListOfItemsAfterSelect = false;
 
   // adds the disabled tag to the HTML input
   export let disabled = false;
@@ -323,6 +326,13 @@
     if (beforeChange(selectedItem, newSelectedItem)) {
       selectedItem = newSelectedItem;
     }
+    
+    if (clearListOfItemsAfterSelect) {
+      listItems = [];
+      filteredListItems = [];
+      clear();
+    }
+    
     return true;
   }
 


### PR DESCRIPTION
After a select the list of items is not cleared. An option should let the developer decide whether the list and the input field should be cleared.